### PR TITLE
Add support for userShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
                     userName = "obe";
                     hostName = "lix";
                     userPass = "idefix";
+                    userShell = "zsh";
                     withNaturalScrolling = true;
                     withNaturalKeyboard = true;
                   };

--- a/modules/autoShutdownOnLoggout.nix
+++ b/modules/autoShutdownOnLoggout.nix
@@ -1,5 +1,15 @@
 {
+  userShell,
+  ...
+}:
+let
+  logout = {
+    bash = ".bash_logout";
+    zsh = ".zlogout";
+  }."${userShell}" or (throw "autoShutdownOnLogout not supported for ${userShell}");
+in
+{
   system.userActivationScripts.autoShutdown = ''
-    echo "sudo poweroff" > ~/.bash_logout
+    echo "sudo poweroff" > ~/${logout}
   '';
 }

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -2,6 +2,8 @@
   hostName,
   userName,
   userPass,
+  userShell,
+  pkgs,
   ...
 }:
 {
@@ -20,9 +22,11 @@
     isNormalUser = true;
     extraGroups = [ "wheel" ]; # Put user in wheel group to…
     password = userPass;
+    shell = pkgs."${userShell}";
   };
   # … enable passwordless ‘sudo’ for user
   security.sudo.wheelNeedsPassword = false;
+  programs."${userShell}".enable = true;
 
   nix.settings.experimental-features = "nix-command flakes";
 }


### PR DESCRIPTION
This PR adds support for setting `userShell` allowing users to set their preferred shell.

The `autoShutdownOnLoggout` module has been changed to support `bash` and `zsh`; adding support for other shells, should be trivial as long as the shell supports an equivalent of `.bash_logout` or `.zlogout`.