### PR TITLE
Add separate Poweroff menu item

### DIFF
--- a/modules/nixcoloredWM/menu.xml
+++ b/modules/nixcoloredWM/menu.xml
@@ -4,6 +4,7 @@
   <item label="Alacritty"><action name="Execute" command="alacritty" /></item>
   <item label="Fontforge"><action name="Execute" command="fontforge" /></item>
   <item label="Reconfigure"><action name="Reconfigure" /></item>
-  <item label="Exit"><action name="Execute" command="sudo poweroff" /></item>
+  <item label="Poweroff"><action name="Execute" command="sudo poweroff" /></item>
+  <item label="Exit"><action name="Exit" /></item>
 </menu>
 </openbox_menu>


### PR DESCRIPTION
To test changes in the graphical environment it can be helpful to exit that without the vm stopping. Hence the addition of a separate menu entry to poweroff the vm from the gui.