### PR TITLE
Wayland, Xserver Improvements

### DIFF
--- a/modules/base.nix
+++ b/modules/base.nix
@@ -28,6 +28,7 @@
   security.sudo.wheelNeedsPassword = false;
   programs."${userShell}".enable = true;
 
+  # suppress noisy startup menu when ~/.zshrc is missing
   system.userActivationScripts.setupShell = pkgs.lib.optionalString (userShell == "zsh") ''
     touch ~/.zshrc
   '';

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -28,5 +28,9 @@
   security.sudo.wheelNeedsPassword = false;
   programs."${userShell}".enable = true;
 
+  system.userActivationScripts.setupShell = pkgs.lib.optionalString (userShell == "zsh") ''
+    touch ~/.zshrc
+  '';
+
   nix.settings.experimental-features = "nix-command flakes";
 }

--- a/modules/wayland/default.nix
+++ b/modules/wayland/default.nix
@@ -16,6 +16,7 @@
     bemenu
     alacritty
     gnused
+    wlr-randr
   ];
 
   environment.sessionVariables = {

--- a/modules/wayland/default.nix
+++ b/modules/wayland/default.nix
@@ -50,9 +50,9 @@
         command =
           with pkgs;
           lib.concatStringsSep " " [
-            "${lib.getExe labwc}"
+            (lib.getExe labwc)
             "-s"
-            "${lib.getExe alacritty}"
+            (lib.getExe alacritty)
           ];
       };
     };

--- a/modules/wayland/default.nix
+++ b/modules/wayland/default.nix
@@ -68,6 +68,7 @@
     in
     ''
       mkdir -p ~/.config/labwc
+      cp --symbolic-link --update ${./rc.xml} ~/.config/labwc/rc.xml
       cp --symbolic-link --update ${./menu.xml} ~/.config/labwc/menu.xml
       cp --symbolic-link --update ${./autostart} ~/.config/labwc/autostart
       cp ${./xkbMacKeyboardConfig} ${envFile}

--- a/modules/wayland/menu.xml
+++ b/modules/wayland/menu.xml
@@ -2,6 +2,7 @@
 <openbox_menu>
 <menu id="root-menu" label="lix">
   <item label="Alacritty"><action name="Execute" command="alacritty" /></item>
+  <item label="Run…"><action name="Execute" command="bemenu-run" /></item>
   <item label="Reconfigure"><action name="Reconfigure" /></item>
   <item label="Poweroff"><action name="Execute" command="sudo poweroff" /></item>
   <item label="Exit"><action name="Exit" /></item>

--- a/modules/wayland/rc.xml
+++ b/modules/wayland/rc.xml
@@ -1,0 +1,9 @@
+<keyboard>
+  <default/>
+  <keybind key="W-Return" onRelease="no">
+    <action name="Execute" command="bemenu-run"/>
+  </keybind>
+  <keybind key="W-C-Return" onRelease="no">
+    <action name="Execute" command="alacritty"/>
+  </keybind>
+</keyboard>

--- a/modules/xserver/default.nix
+++ b/modules/xserver/default.nix
@@ -51,7 +51,8 @@
 
   system.userActivationScripts.setupDesktop =
     ''
-      cp --symbolic-link --update ${./xsession} ~/.xsession
+      cp --symbolic-link --update ${./xprofile} ~/.xprofile
+      cp --symbolic-link --update ${./xresources} ~/.Xresources
     ''
     + lib.optionalString (wm == "twm") ''
       cp --symbolic-link --update ${./twmrc} ~/.twmrc

--- a/modules/xserver/twmrc
+++ b/modules/xserver/twmrc
@@ -81,6 +81,7 @@
             "Hide Iconmgr"         f.hideiconmgr
             ""                     f.nop
             "Xterm"                f.exec "exec xterm -fg maroon -fs 20&"
+            "Run..."               f.exec "exec bemenu-run&"
             ""                     f.nop
             "Kill"                 f.destroy
             "Delete"               f.delete

--- a/modules/xserver/twmrc
+++ b/modules/xserver/twmrc
@@ -80,7 +80,8 @@
             "Show Iconmgr"         f.showiconmgr
             "Hide Iconmgr"         f.hideiconmgr
             ""                     f.nop
-            "Xterm"                f.exec "exec xterm -fg maroon -fs 20&"
+            "Alacritty"            f.exec "exec alacritty&"
+            "Xterm"                f.exec "exec xterm&"
             "Run..."               f.exec "exec bemenu-run&"
             ""                     f.nop
             "Kill"                 f.destroy

--- a/modules/xserver/xprofile
+++ b/modules/xserver/xprofile
@@ -1,0 +1,2 @@
+xsetroot -solid maroon
+xrdb -merge ~/.Xresources

--- a/modules/xserver/xresources
+++ b/modules/xserver/xresources
@@ -1,0 +1,12 @@
+! Use TrueType font
+XTerm*faceName: FreeMonoBold
+XTerm*faceSize: 11
+
+! Set foreground (text) color
+XTerm*foreground: maroon
+
+! (Optional) Background color
+! XTerm*background: black
+
+! Enable anti-aliasing (recommended with TTF)
+XTerm*faceAntialias: true


### PR DESCRIPTION
It makes sense to move fontforge into its own module, yet having to start gui programs from with a terminal is too much of a nuisance for me and I really want some kind of menu.

Hence I added a `Run…` menu entry to wayland and xserver, which uses `bemenu-run` to launch graphical programs.

In addition to that I added more customizability of the xserver via xprofile and xresources.

The `setupShell` activation script is a workaround to avoid the noisy zsh startup when there is no `~/.zshrc` being able to configure zsh, e.g. to enable vi-keybindings via `bindkey -v`, is something that I'd like to see/do rather sooner than later.