### PR TITLE
Fix setting the german layout

### DIFF
--- a/modules/wayland/default.nix
+++ b/modules/wayland/default.nix
@@ -73,6 +73,8 @@
       cp ${./xkbMacKeyboardConfig} ${envFile}
     ''
     + lib.optionalString withNaturalKeyboard ''
+      # file is set a=r in nix store, preventing us from adding to it
+      chmod u+w ${envFile}
       echo XKB_DEFAULT_LAYOUT=de >> ${envFile}
     '';
 }


### PR DESCRIPTION
Of course all files are stored read only in the nix store, so we need to change that if we want to add to a file copied from there.